### PR TITLE
Animal and plant commonality sliders

### DIFF
--- a/Languages/English/Keyed/Keyed.xml
+++ b/Languages/English/Keyed/Keyed.xml
@@ -13,7 +13,13 @@
 	
 	<BMT_DinoWorldLabel>Prehistoric World</BMT_DinoWorldLabel>
 	<BMT_DinoWorldDesc>A complete overhaul to your world: Only prehistoric animals and plants can spawn wild or be sold by traders.</BMT_DinoWorldDesc>
-	
+
+	<BMT_PrehistoricAnimalCommonality>Prehistoric Animal Commonality: {0}%</BMT_PrehistoricAnimalCommonality>
+	<BMT_PrehistoricAnimalCommonalityTooltip>Changes how common wild prehistoric animals are when compared to other animals. By default they are as common as other animals. Values below 100% will make prehistoric animals less common, while values above it will make them appear more frequently.</BMT_PrehistoricAnimalCommonalityTooltip>
+
+	<BMT_PrehistoricPlantCommonality>Prehistoric Plant Commonality: {0}%</BMT_PrehistoricPlantCommonality>
+	<BMT_PrehistoricPlantCommonalityTooltip>Changes how common wild prehistoric plants are when compared to other plants. By default they are as common as other plants. Values below 100% will make prehistoric plants less common, while values above it will make them appear more frequently.</BMT_PrehistoricPlantCommonalityTooltip>
+
 	<BMT_Select>Select</BMT_Select>
 
 	<BMT_NestAlert>{0_indefinite} has angered nearby dinosaurs by getting too close to their nests!</BMT_NestAlert>

--- a/Source/BiomesPrehistoric/PrehistoricSettings.cs
+++ b/Source/BiomesPrehistoric/PrehistoricSettings.cs
@@ -19,16 +19,27 @@ namespace BiomesPrehistoric
     {
         public SpawnOption spawnOption = SpawnOption.DinoAndPlant;
 
-        // this is what saves the setting when the user closes the game
+        // Prehistoric animal commonality. Only active with DinoAndVanilla or DinoAndPlant.
+        public int animalCommonality = 100;
+
+        // Prehistoric plant commonality. Only active with DinoAndPlant.
+        public int plantCommonality = 100;
+
+        // this is what saves the settings when the user closes the game
         public override void ExposeData()
         {
             Scribe_Values.Look(ref spawnOption, "spawnOption", SpawnOption.DinoAndPlant);
+            Scribe_Values.Look(ref animalCommonality, "animalCommonality", 100, true);
+            Scribe_Values.Look(ref plantCommonality, "plantCommonality", 100, true);
         }
     }
 
     // this class handles the interface
     public class BiomesPrehistoricMod : Mod
     {
+        public const int minCommonality = 20;
+        public const int maxCommonality = 500;
+
         public PrehistoricSettings settings;
         public static BiomesPrehistoricMod mod;
 
@@ -61,7 +72,19 @@ namespace BiomesPrehistoric
             
             // DINO WORLD!!!
             SpawnPicker(mainListing, BiomesPrehistoricMod.mod.settings.spawnOption == SpawnOption.DinoWorld, delegate { BiomesPrehistoricMod.mod.settings.spawnOption = SpawnOption.DinoWorld; }, "BMT_DinoWorldLabel", "BMT_DinoWorldDesc", "DinoWorld");
-            
+
+            if (BiomesPrehistoricMod.mod.settings.spawnOption != SpawnOption.DinoWorld)
+            {
+                mainListing.Label("BMT_PrehistoricAnimalCommonality".Translate(BiomesPrehistoricMod.mod.settings.animalCommonality), -1, "BMT_PrehistoricAnimalCommonalityTooltip".Translate());
+                mainListing.verticalSpacing = 1f;
+                BiomesPrehistoricMod.mod.settings.animalCommonality = (int) mainListing.Slider(BiomesPrehistoricMod.mod.settings.animalCommonality, minCommonality, maxCommonality);
+                if (BiomesPrehistoricMod.mod.settings.spawnOption == SpawnOption.DinoAndPlant)
+                {
+                    mainListing.Label("BMT_PrehistoricPlantCommonality".Translate(BiomesPrehistoricMod.mod.settings.plantCommonality), -1, "BMT_PrehistoricPlantCommonalityTooltip".Translate());
+                    BiomesPrehistoricMod.mod.settings.plantCommonality = (int) mainListing.Slider(BiomesPrehistoricMod.mod.settings.plantCommonality, minCommonality, maxCommonality);
+                }
+            }
+
             mainListing.End();
             base.DoSettingsWindowContents(inRect);
 
@@ -69,7 +92,7 @@ namespace BiomesPrehistoric
 
         public static void SpawnPicker(Listing_Standard listing, bool active, Action action, string label, string desc, string iconPath)
         {
-            float height = 160f;
+            const float height = 140f;
             Rect mainRect = new Rect(listing.GetRect(height));
             if (active)
             {

--- a/Source/BiomesPrehistoric/SpawnPatches.cs
+++ b/Source/BiomesPrehistoric/SpawnPatches.cs
@@ -30,6 +30,15 @@ namespace BiomesPrehistoric
 
             return true;
         }
+
+        static void Postfix(PawnKindDef animalDef, ref float __result)
+        {
+            if (BiomesPrehistoricMod.mod.settings.spawnOption != SpawnOption.DinoWorld && Util.IsPrehistoric(animalDef))
+            {
+                __result *= BiomesPrehistoricMod.mod.settings.animalCommonality;
+                __result /= 100.0f;
+            }
+        }
     }
 
 
@@ -288,6 +297,11 @@ namespace BiomesPrehistoric
                 {
                     __result *= 0.000000001f;
                 }
+            }
+            else if(Util.IsPrehistoric(plantDef))
+            {
+                __result *= BiomesPrehistoricMod.mod.settings.plantCommonality;
+                __result /= 100.0f;
             }
         }
     }


### PR DESCRIPTION
This PR adds two commonality sliders to the settings window.

Prehistoric Animal Commonality changes how common wild prehistoric animals are when compared to other animals. It does not appear when the mod is set to “Prehistoric World” mode.

Prehistoric Plant Commonality changes how common wild prehistoric plants are when compared to other plants. It only appears when the mod is set to “Animals and Plants” mode.

![new_settings](https://user-images.githubusercontent.com/3092211/189541431-64717f90-b33b-4a84-ae2a-df3642ff0901.png)
