### PR TITLE
Alpha Biomes rebalance and improved supported

### DIFF
--- a/1.3/Patches/AlphaBiomes_Animals.xml
+++ b/1.3/Patches/AlphaBiomes_Animals.xml
@@ -10,152 +10,216 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/BiomeDef[defName="AB_FeraliskInfestedJungle"]/wildAnimals</xpath>
 					<value>
-						<BMT_Amargasaurus>0.2</BMT_Amargasaurus>
-						<BMT_Ankylosaurus>0.7</BMT_Ankylosaurus>
-						<BMT_Arthropleura>0.5</BMT_Arthropleura>
-						<BMT_Baryonyx>0.03</BMT_Baryonyx>
-						<BMT_Brachiosaurus>0.5</BMT_Brachiosaurus>
-						<BMT_Chungkingosaurus>0.5</BMT_Chungkingosaurus>
-						<BMT_Compsognathus>0.75</BMT_Compsognathus>
-						<BMT_Dimetrodon>0.5</BMT_Dimetrodon>
-						<BMT_Dryosaurus>0.5</BMT_Dryosaurus>
-						<BMT_Gallimimus>0.03</BMT_Gallimimus>
-						<BMT_Iguanodon>0.4</BMT_Iguanodon>
-						<BMT_Kaprosuchus>0.3</BMT_Kaprosuchus>
-						<BMT_Kentrosaurus>0.5</BMT_Kentrosaurus>
-						<BMT_Meganeura>0.5</BMT_Meganeura>
-						<BMT_Pachycephalosaurus>0.3</BMT_Pachycephalosaurus>
-						<BMT_Parasaur>0.2</BMT_Parasaur>
-						<BMT_Protoceratops>0.5</BMT_Protoceratops>
-						<BMT_Spinosaurus>0.02</BMT_Spinosaurus>
-						<BMT_Stygimoloch>0.5</BMT_Stygimoloch>
-						<BMT_Styracosaurus>0.5</BMT_Styracosaurus>
-						<BMT_TRex>0.2</BMT_TRex>
-						<BMT_Titanoboa>0.1</BMT_Titanoboa>
-						<BMT_Triceratops>0.7</BMT_Triceratops>
+						<BMT_Ankylosaurus>0.01</BMT_Ankylosaurus>
+						<BMT_Arthropleura>0.02</BMT_Arthropleura>
+						<BMT_Baryonyx>0.01</BMT_Baryonyx>
+						<BMT_Boomasaur>0.02</BMT_Boomasaur>
+						<BMT_Compsognathus>0.01</BMT_Compsognathus>
+						<BMT_Gallimimus>0.01</BMT_Gallimimus>
+						<BMT_Hypsilophodon>0.01</BMT_Hypsilophodon>
+						<BMT_Kaprosuchus>0.01</BMT_Kaprosuchus>
+						<BMT_Kentrosaurus>0.01</BMT_Kentrosaurus>
+						<BMT_Lystrosaur>0.01</BMT_Lystrosaur>
+						<BMT_Meganeura>0.03</BMT_Meganeura>
+						<BMT_Protoceratops>0.01</BMT_Protoceratops>
+						<BMT_Pulmonoscorpius>0.02</BMT_Pulmonoscorpius>
+						<BMT_Styracosaurus>0.01</BMT_Styracosaurus>
+						<BMT_TRex>0.01</BMT_TRex>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/BiomeDef[defName="AB_GallatrossGraveyard"]/wildAnimals</xpath>
 					<value>
-						<BMT_Apatosaurus>0.02</BMT_Apatosaurus>
-						<BMT_Arthropleura>0.2</BMT_Arthropleura>
-						<BMT_Borealopelta>0.5</BMT_Borealopelta>
-						<BMT_Brachiosaurus>0.02</BMT_Brachiosaurus>
-						<BMT_Carnotaurus>0.05</BMT_Carnotaurus>
-						<BMT_Chungkingosaurus>0.2</BMT_Chungkingosaurus>
-						<BMT_Dilophosaurus>0.03</BMT_Dilophosaurus>
-						<BMT_Dryosaurus>0.02</BMT_Dryosaurus>
+						<BMT_Allosaurus>0.05</BMT_Allosaurus>
+						<BMT_Boomasaur>0.05</BMT_Boomasaur>
+						<BMT_Brachiosaurus>0.01</BMT_Brachiosaurus>
+						<BMT_Carnotaurus>0.04</BMT_Carnotaurus>
+						<BMT_Dilophosaurus>0.02</BMT_Dilophosaurus>
+						<BMT_Dryosaurus>0.01</BMT_Dryosaurus>
 						<BMT_Inostrancevia>0.01</BMT_Inostrancevia>
-						<BMT_Meganeura>0.5</BMT_Meganeura>
-						<BMT_Oviraptor>0.2</BMT_Oviraptor>
-						<BMT_Parasaur>0.4</BMT_Parasaur>
-						<BMT_Polacanthus>0.5</BMT_Polacanthus>
-						<BMT_Styracosaurus>0.5</BMT_Styracosaurus>
-						<BMT_TRex>0.3</BMT_TRex>
-						<BMT_Velociraptor>0.5</BMT_Velociraptor>
+						<BMT_Meganeura>0.05</BMT_Meganeura>
+						<BMT_Nanosaurus>0.05</BMT_Nanosaurus>
+						<BMT_Parasaur>0.05</BMT_Parasaur>
+						<BMT_Troodon>0.1</BMT_Troodon>
+						<BMT_Utahraptor>0.02</BMT_Utahraptor>
+						<BMT_Velociraptor>0.04</BMT_Velociraptor>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/BiomeDef[defName="AB_GelatinousSuperorganism"]/wildAnimals</xpath>
 					<value>
-						<BMT_Amargasaurus>0.8</BMT_Amargasaurus>
-						<BMT_Ankylosaurus>0.5</BMT_Ankylosaurus>
-						<BMT_Apatosaurus>0.5</BMT_Apatosaurus>
-						<BMT_Arthropleura>0.5</BMT_Arthropleura>
-						<BMT_Baryonyx>0.07</BMT_Baryonyx>
-						<BMT_Brachiosaurus>0.3</BMT_Brachiosaurus>
-						<BMT_Chungkingosaurus>0.5</BMT_Chungkingosaurus>
-						<BMT_Dimetrodon>0.5</BMT_Dimetrodon>
-						<BMT_Dryosaurus>0.3</BMT_Dryosaurus>
-						<BMT_Gallimimus>0.6</BMT_Gallimimus>
-						<BMT_Iguanodon>0.5</BMT_Iguanodon>
-						<BMT_Kaprosuchus>0.5</BMT_Kaprosuchus>
-						<BMT_Kentrosaurus>0.5</BMT_Kentrosaurus>
-						<BMT_Meganeura>0.5</BMT_Meganeura>
-						<BMT_Protoceratops>0.5</BMT_Protoceratops>
-						<BMT_Spinosaurus>0.04</BMT_Spinosaurus>
-						<BMT_Stygimoloch>0.2</BMT_Stygimoloch>
-						<BMT_Styracosaurus>0.5</BMT_Styracosaurus>
-						<BMT_TRex>0.1</BMT_TRex>
-						<BMT_Triceratops>0.5</BMT_Triceratops>
+						<BMT_Amargasaurus>0.05</BMT_Amargasaurus>
+						<BMT_Apatosaurus>0.08</BMT_Apatosaurus>
+						<BMT_Arthropleura>0.2</BMT_Arthropleura>
+						<BMT_Baryonyx>0.02</BMT_Baryonyx>
+						<BMT_Boomasaur>0.08</BMT_Boomasaur>
+						<BMT_Chasmosaurus>0.01</BMT_Chasmosaurus>
+						<BMT_Deinonychus>0.05</BMT_Deinonychus>
+						<BMT_Dimetrodon>0.08</BMT_Dimetrodon>
+						<BMT_Diplocaulus>0.05</BMT_Diplocaulus>
+						<BMT_Gallimimus>0.05</BMT_Gallimimus>
+						<BMT_Iguanodon>0.05</BMT_Iguanodon>
+						<BMT_Kaprosuchus>0.05</BMT_Kaprosuchus>
+						<BMT_Meganeura>0.1</BMT_Meganeura>
+						<BMT_Olorotitan>0.05</BMT_Olorotitan>
+						<BMT_Onchiodon>0.1</BMT_Onchiodon>
+						<BMT_Panphagia>0.05</BMT_Panphagia>
+						<BMT_Protoceratops>0.1</BMT_Protoceratops>
+						<BMT_Spinosaurus>0.02</BMT_Spinosaurus>
+						<BMT_Stegoceras>0.05</BMT_Stegoceras>
+						<BMT_Stygimoloch>0.05</BMT_Stygimoloch>
+						<BMT_Therizinosaurus>0.01</BMT_Therizinosaurus>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BiomeDef[defName="AB_IdyllicMeadows"]/wildAnimals</xpath>
+					<value>
+						<BMT_Amargasaurus>0.1</BMT_Amargasaurus>
+						<BMT_Boomasaur>0.05</BMT_Boomasaur>
+						<BMT_Borealopelta>0.05</BMT_Borealopelta>
+						<BMT_Camarasaurus>0.06</BMT_Camarasaurus>
+						<BMT_Centrosaurus>0.05</BMT_Centrosaurus>
+						<BMT_Edmontosaurus>0.08</BMT_Edmontosaurus>
+						<BMT_Homalocephale>0.03</BMT_Homalocephale>
+						<BMT_Leaellynasaura>0.02</BMT_Leaellynasaura>
+						<BMT_Meganeura>0.03</BMT_Meganeura>
+						<BMT_Minmi>0.08</BMT_Minmi>
+						<BMT_Olorotitan>0.02</BMT_Olorotitan>
+						<BMT_Pachyrhinosaurus>0.02</BMT_Pachyrhinosaurus>
+						<BMT_Polacanthus>0.02</BMT_Polacanthus>
+						<BMT_Protoceratops>0.05</BMT_Protoceratops>
+						<BMT_Psittacosaurus>0.04</BMT_Psittacosaurus>
+						<BMT_Struthiomimus>0.08</BMT_Struthiomimus>
+						<BMT_Styracosaurus>0.04</BMT_Styracosaurus>
+						<BMT_Triceratops>0.03</BMT_Triceratops>
+						<BMT_Troodon>0.02</BMT_Troodon>
+						<BMT_Yinlong>0.05</BMT_Yinlong>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BiomeDef[defName="AB_MechanoidIntrusion"]/wildAnimals</xpath>
+					<value>
+						<BMT_Compsognathus>0.01</BMT_Compsognathus>
+						<BMT_Hypsilophodon>0.2</BMT_Hypsilophodon>
+						<BMT_Nanosaurus>0.02</BMT_Nanosaurus>
+					</value>
+				</li>
+
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/BiomeDef[defName="AB_MiasmicMangrove"]/wildAnimals</xpath>
+					<value>
+						<BMT_Apatosaurus>0.02</BMT_Apatosaurus>
+						<BMT_Arthropleura>0.1</BMT_Arthropleura>
+						<BMT_Baryonyx>0.02</BMT_Baryonyx>
+						<BMT_Boomasaur>0.01</BMT_Boomasaur>
+						<BMT_Brachiosaurus>0.02</BMT_Brachiosaurus>
+						<BMT_Chungkingosaurus>0.05</BMT_Chungkingosaurus>
+						<BMT_Deinonychus>0.01</BMT_Deinonychus>
+						<BMT_Diplocaulus>0.03</BMT_Diplocaulus>
+						<BMT_Dryosaurus>0.02</BMT_Dryosaurus>
+						<BMT_Iguanodon>0.04</BMT_Iguanodon>
+						<BMT_Kaprosuchus>0.15</BMT_Kaprosuchus>
+						<BMT_Lystrosaur>0.1</BMT_Lystrosaur>
+						<BMT_Maiasaura>0.05</BMT_Maiasaura>
+						<BMT_Meganeura>0.08</BMT_Meganeura>
+						<BMT_Onchiodon>0.05</BMT_Onchiodon>
+						<BMT_Ouranosaurus>0.02</BMT_Ouranosaurus>
+						<BMT_Pachycephalosaurus>0.02</BMT_Pachycephalosaurus>
+						<BMT_Protoceratops>0.02</BMT_Protoceratops>
+						<BMT_Psittacosaurus>0.03</BMT_Psittacosaurus>
+						<BMT_Pulmonoscorpius>0.1</BMT_Pulmonoscorpius>
+						<BMT_Spinosaurus>0.03</BMT_Spinosaurus>
+						<BMT_Stegoceras>0.02</BMT_Stegoceras>
+						<BMT_Titanoboa>0.08</BMT_Titanoboa>
+						<BMT_Wannanosaurus>0.05</BMT_Wannanosaurus>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/BiomeDef[defName="AB_MycoticJungle"]/wildAnimals</xpath>
 					<value>
-						<BMT_Amargasaurus>0.2</BMT_Amargasaurus>
-						<BMT_Ankylosaurus>0.7</BMT_Ankylosaurus>
-						<BMT_Arthropleura>0.5</BMT_Arthropleura>
-						<BMT_Baryonyx>0.03</BMT_Baryonyx>
-						<BMT_Brachiosaurus>0.5</BMT_Brachiosaurus>
-						<BMT_Chungkingosaurus>0.5</BMT_Chungkingosaurus>
-						<BMT_Compsognathus>0.75</BMT_Compsognathus>
-						<BMT_Dimetrodon>0.5</BMT_Dimetrodon>
-						<BMT_Dryosaurus>0.5</BMT_Dryosaurus>
-						<BMT_Gallimimus>0.03</BMT_Gallimimus>
-						<BMT_Iguanodon>0.4</BMT_Iguanodon>
-						<BMT_Kaprosuchus>0.3</BMT_Kaprosuchus>
-						<BMT_Kentrosaurus>0.5</BMT_Kentrosaurus>
-						<BMT_Meganeura>0.5</BMT_Meganeura>
-						<BMT_Pachycephalosaurus>0.3</BMT_Pachycephalosaurus>
-						<BMT_Parasaur>0.2</BMT_Parasaur>
-						<BMT_Protoceratops>0.5</BMT_Protoceratops>
-						<BMT_Spinosaurus>0.02</BMT_Spinosaurus>
-						<BMT_Stygimoloch>0.5</BMT_Stygimoloch>
-						<BMT_Styracosaurus>0.5</BMT_Styracosaurus>
-						<BMT_TRex>0.2</BMT_TRex>
-						<BMT_Titanoboa>0.1</BMT_Titanoboa>
-						<BMT_Triceratops>0.7</BMT_Triceratops>
+						<BMT_Amargasaurus>0.03</BMT_Amargasaurus>
+						<BMT_Ankylosaurus>0.1</BMT_Ankylosaurus>
+						<BMT_Baryonyx>0.02</BMT_Baryonyx>
+						<BMT_Boomasaur>0.1</BMT_Boomasaur>
+						<BMT_Centrosaurus>0.02</BMT_Centrosaurus>
+						<BMT_Chungkingosaurus>0.06</BMT_Chungkingosaurus>
+						<BMT_Compsognathus>0.1</BMT_Compsognathus>
+						<BMT_Edmontosaurus>0.06</BMT_Edmontosaurus>
+						<BMT_Gallimimus>0.02</BMT_Gallimimus>
+						<BMT_Hypsilophodon>0.02</BMT_Hypsilophodon>
+						<BMT_Iguanodon>0.05</BMT_Iguanodon>
+						<BMT_Kentrosaurus>0.07</BMT_Kentrosaurus>
+						<BMT_Lystrosaur>0.08</BMT_Lystrosaur>
+						<BMT_Meganeura>0.04</BMT_Meganeura>
+						<BMT_Minmi>0.07</BMT_Minmi>
+						<BMT_Pachycephalosaurus>0.06</BMT_Pachycephalosaurus>
+						<BMT_Pachyrhinosaurus>0.02</BMT_Pachyrhinosaurus>
+						<BMT_Parasaur>0.03</BMT_Parasaur>
+						<BMT_Spinosaurus>0.01</BMT_Spinosaurus>
+						<BMT_Stygimoloch>0.1</BMT_Stygimoloch>
+						<BMT_Therizinosaurus>0.07</BMT_Therizinosaurus>
+						<BMT_Titanoboa>0.05</BMT_Titanoboa>
+						<BMT_TRex>0.03</BMT_TRex>
+						<BMT_Triceratops>0.08</BMT_Triceratops>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/BiomeDef[defName="AB_OcularForest"]/wildAnimals</xpath>
 					<value>
-						<BMT_Amargasaurus>0.3</BMT_Amargasaurus>
-						<BMT_Ankylosaurus>0.3</BMT_Ankylosaurus>
-						<BMT_Apatosaurus>0.2</BMT_Apatosaurus>
-						<BMT_Arthropleura>0.5</BMT_Arthropleura>
-						<BMT_Borealopelta>0.5</BMT_Borealopelta>
-						<BMT_Brachiosaurus>0.15</BMT_Brachiosaurus>
-						<BMT_Chungkingosaurus>0.5</BMT_Chungkingosaurus>
-						<BMT_Compsognathus>0.75</BMT_Compsognathus>
-						<BMT_Dimetrodon>0.5</BMT_Dimetrodon>
-						<BMT_Dryosaurus>0.1</BMT_Dryosaurus>
-						<BMT_Gallimimus>0.3</BMT_Gallimimus>
-						<BMT_Homalocephale>0.1</BMT_Homalocephale>
-						<BMT_Iguanodon>0.3</BMT_Iguanodon>
-						<BMT_Kaprosuchus>0.3</BMT_Kaprosuchus>
-						<BMT_Kentrosaurus>0.5</BMT_Kentrosaurus>
-						<BMT_Pachycephalosaurus>0.3</BMT_Pachycephalosaurus>
-						<BMT_Parasaur>0.4</BMT_Parasaur>
-						<BMT_Polacanthus>0.5</BMT_Polacanthus>
-						<BMT_Protoceratops>0.5</BMT_Protoceratops>
-						<BMT_Stegosaurus>0.5</BMT_Stegosaurus>
-						<BMT_Stygimoloch>0.4</BMT_Stygimoloch>
-						<BMT_Styracosaurus>0.5</BMT_Styracosaurus>
-						<BMT_TRex>0.1</BMT_TRex>
-						<BMT_Triceratops>0.3</BMT_Triceratops>
+						<BMT_Ankylosaurus>0.05</BMT_Ankylosaurus>
+						<BMT_Arthropleura>0.05</BMT_Arthropleura>
+						<BMT_Brachiosaurus>0.02</BMT_Brachiosaurus>
+						<BMT_Chasmosaurus>0.02</BMT_Chasmosaurus>
+						<BMT_Chungkingosaurus>0.05</BMT_Chungkingosaurus>
+						<BMT_Compsognathus>0.08</BMT_Compsognathus>
+						<BMT_Dimetrodon>0.05</BMT_Dimetrodon>
+						<BMT_Dryosaurus>0.03</BMT_Dryosaurus>
+						<BMT_Gallimimus>0.05</BMT_Gallimimus>
+						<BMT_Homalocephale>0.01</BMT_Homalocephale>
+						<BMT_Minmi>0.02</BMT_Minmi>
+						<BMT_Pachycephalosaurus>0.03</BMT_Pachycephalosaurus>
+						<BMT_Panphagia>0.05</BMT_Panphagia>
+						<BMT_Parasaur>0.05</BMT_Parasaur>
+						<BMT_Polacanthus>0.05</BMT_Polacanthus>
+						<BMT_Protoceratops>0.1</BMT_Protoceratops>
+						<BMT_Stegosaurus>0.08</BMT_Stegosaurus>
+						<BMT_Styracosaurus>0.08</BMT_Styracosaurus>
+						<BMT_TRex>0.01</BMT_TRex>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/BiomeDef[defName="AB_PropaneLakes"]/wildAnimals</xpath>
 					<value>
-						<BMT_Borealopelta>0.5</BMT_Borealopelta>
-						<BMT_Homalocephale>0.05</BMT_Homalocephale>
-						<BMT_Polacanthus>0.5</BMT_Polacanthus>
+						<BMT_Borealopelta>0.05</BMT_Borealopelta>
+						<BMT_Homalocephale>0.02</BMT_Homalocephale>
+						<BMT_Leaellynasaura>0.05</BMT_Leaellynasaura>
+						<BMT_Polacanthus>0.02</BMT_Polacanthus>
+						<BMT_Timimus>0.05</BMT_Timimus>
+						<BMT_Yutyrannus>0.05</BMT_Yutyrannus>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/BiomeDef[defName="AB_PyroclasticConflagration"]/wildAnimals</xpath>
 					<value>
+						<BMT_Allosaurus>0.05</BMT_Allosaurus>
+						<BMT_Boomasaur>0.1</BMT_Boomasaur>
 						<BMT_Dilophosaurus>0.05</BMT_Dilophosaurus>
+						<BMT_Hypsilophodon>0.2</BMT_Hypsilophodon>
+						<BMT_Inostrancevia>0.1</BMT_Inostrancevia>
+						<BMT_Kentrosaurus>0.15</BMT_Kentrosaurus>
+						<BMT_Lystrosaur>0.2</BMT_Lystrosaur>
+						<BMT_Nanosaurus>0.05</BMT_Nanosaurus>
+						<BMT_Oviraptor>0.01</BMT_Oviraptor>
+						<BMT_Struthiomimus>0.05</BMT_Struthiomimus>
+						<BMT_Velociraptor>0.05</BMT_Velociraptor>
 					</value>
 				</li>
 
@@ -164,18 +228,33 @@
 					<value>
 						<BMT_Carnotaurus>0.03</BMT_Carnotaurus>
 						<BMT_Dilophosaurus>0.07</BMT_Dilophosaurus>
+						<BMT_Hypsilophodon>0.1</BMT_Hypsilophodon>
 						<BMT_Inostrancevia>0.01</BMT_Inostrancevia>
-						<BMT_Velociraptor>0.5</BMT_Velociraptor>
+						<BMT_Leaellynasaura>0.03</BMT_Leaellynasaura>
+						<BMT_Nanosaurus>0.05</BMT_Nanosaurus>
+						<BMT_Ouranosaurus>0.01</BMT_Ouranosaurus>
+						<BMT_Therizinosaurus>0.01</BMT_Therizinosaurus>
+						<BMT_Velociraptor>0.15</BMT_Velociraptor>
 					</value>
 				</li>
 
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/BiomeDef[defName="AB_TarPits"]/wildAnimals</xpath>
 					<value>
+						<BMT_Allosaurus>0.1</BMT_Allosaurus>
+						<BMT_Boomasaur>0.1</BMT_Boomasaur>
 						<BMT_Carnotaurus>0.03</BMT_Carnotaurus>
 						<BMT_Dilophosaurus>0.07</BMT_Dilophosaurus>
 						<BMT_Inostrancevia>0.01</BMT_Inostrancevia>
-						<BMT_Velociraptor>0.5</BMT_Velociraptor>
+						<BMT_Maiasaura>0.05</BMT_Maiasaura>
+						<BMT_Meganeura>0.15</BMT_Meganeura>
+						<BMT_Nanosaurus>0.05</BMT_Nanosaurus>
+						<BMT_Ouranosaurus>0.1</BMT_Ouranosaurus>
+						<BMT_Oviraptor>0.05</BMT_Oviraptor>
+						<BMT_Protoceratops>0.1</BMT_Protoceratops>
+						<BMT_Utahraptor>0.1</BMT_Utahraptor>
+						<BMT_Velociraptor>0.05</BMT_Velociraptor>
+						<BMT_Yinlong>0.1</BMT_Yinlong>
 					</value>
 				</li>
 

--- a/1.3/Patches/AlphaBiomes_Animals.xml
+++ b/1.3/Patches/AlphaBiomes_Animals.xml
@@ -7,178 +7,178 @@
 
 		<match Class="PatchOperationSequence">
 			<operations>
-				<li Class="PatchOperationAdd"> 
+				<li Class="PatchOperationAdd">
 					<xpath>Defs/BiomeDef[defName="AB_FeraliskInfestedJungle"]/wildAnimals</xpath>
 					<value>
-		    <BMT_Kaprosuchus>0.3</BMT_Kaprosuchus>
-		    <BMT_Protoceratops>0.5</BMT_Protoceratops>
-		    <BMT_Compsognathus>0.75</BMT_Compsognathus>
-		    <BMT_Kentrosaurus>0.5</BMT_Kentrosaurus>
-			<BMT_Dimetrodon>0.5</BMT_Dimetrodon>
-		    <BMT_Styracosaurus>0.5</BMT_Styracosaurus>
-		    <BMT_Chungkingosaurus>0.5</BMT_Chungkingosaurus>
-		    <BMT_Meganeura>0.5</BMT_Meganeura>
-		    <BMT_Arthropleura>0.5</BMT_Arthropleura>
-			<BMT_Brachiosaurus>0.5</BMT_Brachiosaurus>
-			<BMT_TRex>0.2</BMT_TRex>
-			<BMT_Dryosaurus>0.5</BMT_Dryosaurus>
-			<BMT_Amargasaurus>0.2</BMT_Amargasaurus>
-			<BMT_Spinosaurus>0.02</BMT_Spinosaurus>
-			<BMT_Titanoboa>0.1</BMT_Titanoboa>
-			<BMT_Ankylosaurus>0.7</BMT_Ankylosaurus>
-			<BMT_Triceratops>0.7</BMT_Triceratops>
-			<BMT_Gallimimus>0.03</BMT_Gallimimus>
-			<BMT_Baryonyx>0.03</BMT_Baryonyx>
-			<BMT_Pachycephalosaurus>0.3</BMT_Pachycephalosaurus>
-			<BMT_Stygimoloch>0.5</BMT_Stygimoloch>
-			<BMT_Parasaur>0.2</BMT_Parasaur>
-			<BMT_Iguanodon>0.4</BMT_Iguanodon>
+						<BMT_Amargasaurus>0.2</BMT_Amargasaurus>
+						<BMT_Ankylosaurus>0.7</BMT_Ankylosaurus>
+						<BMT_Arthropleura>0.5</BMT_Arthropleura>
+						<BMT_Baryonyx>0.03</BMT_Baryonyx>
+						<BMT_Brachiosaurus>0.5</BMT_Brachiosaurus>
+						<BMT_Chungkingosaurus>0.5</BMT_Chungkingosaurus>
+						<BMT_Compsognathus>0.75</BMT_Compsognathus>
+						<BMT_Dimetrodon>0.5</BMT_Dimetrodon>
+						<BMT_Dryosaurus>0.5</BMT_Dryosaurus>
+						<BMT_Gallimimus>0.03</BMT_Gallimimus>
+						<BMT_Iguanodon>0.4</BMT_Iguanodon>
+						<BMT_Kaprosuchus>0.3</BMT_Kaprosuchus>
+						<BMT_Kentrosaurus>0.5</BMT_Kentrosaurus>
+						<BMT_Meganeura>0.5</BMT_Meganeura>
+						<BMT_Pachycephalosaurus>0.3</BMT_Pachycephalosaurus>
+						<BMT_Parasaur>0.2</BMT_Parasaur>
+						<BMT_Protoceratops>0.5</BMT_Protoceratops>
+						<BMT_Spinosaurus>0.02</BMT_Spinosaurus>
+						<BMT_Stygimoloch>0.5</BMT_Stygimoloch>
+						<BMT_Styracosaurus>0.5</BMT_Styracosaurus>
+						<BMT_TRex>0.2</BMT_TRex>
+						<BMT_Titanoboa>0.1</BMT_Titanoboa>
+						<BMT_Triceratops>0.7</BMT_Triceratops>
 					</value>
 				</li>
-				
-				<li Class="PatchOperationAdd"> 
+
+				<li Class="PatchOperationAdd">
 					<xpath>Defs/BiomeDef[defName="AB_GallatrossGraveyard"]/wildAnimals</xpath>
 					<value>
-		    <BMT_Polacanthus>0.5</BMT_Polacanthus>
-		    <BMT_Borealopelta>0.5</BMT_Borealopelta>
-		    <BMT_Velociraptor>0.5</BMT_Velociraptor>
-		    <BMT_Styracosaurus>0.5</BMT_Styracosaurus>
-		    <BMT_Chungkingosaurus>0.2</BMT_Chungkingosaurus>
-			<BMT_Meganeura>0.5</BMT_Meganeura>
-		    <BMT_Arthropleura>0.2</BMT_Arthropleura>
-			<BMT_Apatosaurus>0.02</BMT_Apatosaurus>
-			<BMT_Oviraptor>0.2</BMT_Oviraptor>
-			<BMT_Brachiosaurus>0.02</BMT_Brachiosaurus>
-			<BMT_TRex>0.3</BMT_TRex>
-			<BMT_Dryosaurus>0.02</BMT_Dryosaurus>
-			<BMT_Dilophosaurus>0.03</BMT_Dilophosaurus>
-			<BMT_Carnotaurus>0.05</BMT_Carnotaurus>
-			<BMT_Parasaur>0.4</BMT_Parasaur>
-			<BMT_Inostrancevia>0.01</BMT_Inostrancevia>
+						<BMT_Apatosaurus>0.02</BMT_Apatosaurus>
+						<BMT_Arthropleura>0.2</BMT_Arthropleura>
+						<BMT_Borealopelta>0.5</BMT_Borealopelta>
+						<BMT_Brachiosaurus>0.02</BMT_Brachiosaurus>
+						<BMT_Carnotaurus>0.05</BMT_Carnotaurus>
+						<BMT_Chungkingosaurus>0.2</BMT_Chungkingosaurus>
+						<BMT_Dilophosaurus>0.03</BMT_Dilophosaurus>
+						<BMT_Dryosaurus>0.02</BMT_Dryosaurus>
+						<BMT_Inostrancevia>0.01</BMT_Inostrancevia>
+						<BMT_Meganeura>0.5</BMT_Meganeura>
+						<BMT_Oviraptor>0.2</BMT_Oviraptor>
+						<BMT_Parasaur>0.4</BMT_Parasaur>
+						<BMT_Polacanthus>0.5</BMT_Polacanthus>
+						<BMT_Styracosaurus>0.5</BMT_Styracosaurus>
+						<BMT_TRex>0.3</BMT_TRex>
+						<BMT_Velociraptor>0.5</BMT_Velociraptor>
 					</value>
 				</li>
-				
-				<li Class="PatchOperationAdd"> 
+
+				<li Class="PatchOperationAdd">
 					<xpath>Defs/BiomeDef[defName="AB_GelatinousSuperorganism"]/wildAnimals</xpath>
 					<value>
-		    <BMT_Kaprosuchus>0.5</BMT_Kaprosuchus>
-		    <BMT_Protoceratops>0.5</BMT_Protoceratops>
-            <BMT_Kentrosaurus>0.5</BMT_Kentrosaurus>
-		    <BMT_Dimetrodon>0.5</BMT_Dimetrodon>
-		    <BMT_Styracosaurus>0.5</BMT_Styracosaurus>
-		    <BMT_Chungkingosaurus>0.5</BMT_Chungkingosaurus>
-			<BMT_Meganeura>0.5</BMT_Meganeura>
-		    <BMT_Arthropleura>0.5</BMT_Arthropleura>
-		    <BMT_Apatosaurus>0.5</BMT_Apatosaurus>
-			<BMT_Brachiosaurus>0.3</BMT_Brachiosaurus>
-			<BMT_TRex>0.1</BMT_TRex>
-			<BMT_Dryosaurus>0.3</BMT_Dryosaurus>
-			<BMT_Amargasaurus>0.8</BMT_Amargasaurus>
-			<BMT_Spinosaurus>0.04</BMT_Spinosaurus>
-			<BMT_Ankylosaurus>0.5</BMT_Ankylosaurus>
-			<BMT_Triceratops>0.5</BMT_Triceratops>
-			<BMT_Gallimimus>0.6</BMT_Gallimimus>
-			<BMT_Baryonyx>0.07</BMT_Baryonyx>
-			<BMT_Stygimoloch>0.2</BMT_Stygimoloch>
-			<BMT_Iguanodon>0.5</BMT_Iguanodon>
+						<BMT_Amargasaurus>0.8</BMT_Amargasaurus>
+						<BMT_Ankylosaurus>0.5</BMT_Ankylosaurus>
+						<BMT_Apatosaurus>0.5</BMT_Apatosaurus>
+						<BMT_Arthropleura>0.5</BMT_Arthropleura>
+						<BMT_Baryonyx>0.07</BMT_Baryonyx>
+						<BMT_Brachiosaurus>0.3</BMT_Brachiosaurus>
+						<BMT_Chungkingosaurus>0.5</BMT_Chungkingosaurus>
+						<BMT_Dimetrodon>0.5</BMT_Dimetrodon>
+						<BMT_Dryosaurus>0.3</BMT_Dryosaurus>
+						<BMT_Gallimimus>0.6</BMT_Gallimimus>
+						<BMT_Iguanodon>0.5</BMT_Iguanodon>
+						<BMT_Kaprosuchus>0.5</BMT_Kaprosuchus>
+						<BMT_Kentrosaurus>0.5</BMT_Kentrosaurus>
+						<BMT_Meganeura>0.5</BMT_Meganeura>
+						<BMT_Protoceratops>0.5</BMT_Protoceratops>
+						<BMT_Spinosaurus>0.04</BMT_Spinosaurus>
+						<BMT_Stygimoloch>0.2</BMT_Stygimoloch>
+						<BMT_Styracosaurus>0.5</BMT_Styracosaurus>
+						<BMT_TRex>0.1</BMT_TRex>
+						<BMT_Triceratops>0.5</BMT_Triceratops>
 					</value>
 				</li>
-				
-				<li Class="PatchOperationAdd"> 
+
+				<li Class="PatchOperationAdd">
 					<xpath>Defs/BiomeDef[defName="AB_MycoticJungle"]/wildAnimals</xpath>
 					<value>
-		    <BMT_Kaprosuchus>0.3</BMT_Kaprosuchus>
-		    <BMT_Protoceratops>0.5</BMT_Protoceratops>
-		    <BMT_Compsognathus>0.75</BMT_Compsognathus>
-		    <BMT_Kentrosaurus>0.5</BMT_Kentrosaurus>
-			<BMT_Dimetrodon>0.5</BMT_Dimetrodon>
-		    <BMT_Styracosaurus>0.5</BMT_Styracosaurus>
-		    <BMT_Chungkingosaurus>0.5</BMT_Chungkingosaurus>
-		    <BMT_Meganeura>0.5</BMT_Meganeura>
-		    <BMT_Arthropleura>0.5</BMT_Arthropleura>
-			<BMT_Brachiosaurus>0.5</BMT_Brachiosaurus>
-			<BMT_TRex>0.2</BMT_TRex>
-			<BMT_Dryosaurus>0.5</BMT_Dryosaurus>
-			<BMT_Amargasaurus>0.2</BMT_Amargasaurus>
-			<BMT_Spinosaurus>0.02</BMT_Spinosaurus>
-			<BMT_Titanoboa>0.1</BMT_Titanoboa>
-			<BMT_Ankylosaurus>0.7</BMT_Ankylosaurus>
-			<BMT_Triceratops>0.7</BMT_Triceratops>
-			<BMT_Gallimimus>0.03</BMT_Gallimimus>
-			<BMT_Baryonyx>0.03</BMT_Baryonyx>
-			<BMT_Pachycephalosaurus>0.3</BMT_Pachycephalosaurus>
-			<BMT_Stygimoloch>0.5</BMT_Stygimoloch>
-			<BMT_Parasaur>0.2</BMT_Parasaur>
-			<BMT_Iguanodon>0.4</BMT_Iguanodon>
+						<BMT_Amargasaurus>0.2</BMT_Amargasaurus>
+						<BMT_Ankylosaurus>0.7</BMT_Ankylosaurus>
+						<BMT_Arthropleura>0.5</BMT_Arthropleura>
+						<BMT_Baryonyx>0.03</BMT_Baryonyx>
+						<BMT_Brachiosaurus>0.5</BMT_Brachiosaurus>
+						<BMT_Chungkingosaurus>0.5</BMT_Chungkingosaurus>
+						<BMT_Compsognathus>0.75</BMT_Compsognathus>
+						<BMT_Dimetrodon>0.5</BMT_Dimetrodon>
+						<BMT_Dryosaurus>0.5</BMT_Dryosaurus>
+						<BMT_Gallimimus>0.03</BMT_Gallimimus>
+						<BMT_Iguanodon>0.4</BMT_Iguanodon>
+						<BMT_Kaprosuchus>0.3</BMT_Kaprosuchus>
+						<BMT_Kentrosaurus>0.5</BMT_Kentrosaurus>
+						<BMT_Meganeura>0.5</BMT_Meganeura>
+						<BMT_Pachycephalosaurus>0.3</BMT_Pachycephalosaurus>
+						<BMT_Parasaur>0.2</BMT_Parasaur>
+						<BMT_Protoceratops>0.5</BMT_Protoceratops>
+						<BMT_Spinosaurus>0.02</BMT_Spinosaurus>
+						<BMT_Stygimoloch>0.5</BMT_Stygimoloch>
+						<BMT_Styracosaurus>0.5</BMT_Styracosaurus>
+						<BMT_TRex>0.2</BMT_TRex>
+						<BMT_Titanoboa>0.1</BMT_Titanoboa>
+						<BMT_Triceratops>0.7</BMT_Triceratops>
 					</value>
 				</li>
-				
-				<li Class="PatchOperationAdd"> 
+
+				<li Class="PatchOperationAdd">
 					<xpath>Defs/BiomeDef[defName="AB_OcularForest"]/wildAnimals</xpath>
 					<value>
-		    <BMT_Kaprosuchus>0.3</BMT_Kaprosuchus>
-		    <BMT_Polacanthus>0.5</BMT_Polacanthus>
-		    <BMT_Borealopelta>0.5</BMT_Borealopelta>
-		    <BMT_Protoceratops>0.5</BMT_Protoceratops>
-		    <BMT_Compsognathus>0.75</BMT_Compsognathus>
-		    <BMT_Kentrosaurus>0.5</BMT_Kentrosaurus>
-		    <BMT_Dimetrodon>0.5</BMT_Dimetrodon>
-		    <BMT_Styracosaurus>0.5</BMT_Styracosaurus>
-		    <BMT_Chungkingosaurus>0.5</BMT_Chungkingosaurus>
-		    <BMT_Arthropleura>0.5</BMT_Arthropleura>
-			<BMT_Apatosaurus>0.2</BMT_Apatosaurus>
-			<BMT_Brachiosaurus>0.15</BMT_Brachiosaurus>
-			<BMT_TRex>0.1</BMT_TRex>
-			<BMT_Dryosaurus>0.1</BMT_Dryosaurus>
-			<BMT_Amargasaurus>0.3</BMT_Amargasaurus>
-			<BMT_Stegosaurus>0.5</BMT_Stegosaurus>
-			<BMT_Ankylosaurus>0.3</BMT_Ankylosaurus>
-			<BMT_Triceratops>0.3</BMT_Triceratops>
-			<BMT_Gallimimus>0.3</BMT_Gallimimus>
-			<BMT_Pachycephalosaurus>0.3</BMT_Pachycephalosaurus>
-			<BMT_Stygimoloch>0.4</BMT_Stygimoloch>
-			<BMT_Homalocephale>0.1</BMT_Homalocephale>
-			<BMT_Parasaur>0.4</BMT_Parasaur>
-			<BMT_Iguanodon>0.3</BMT_Iguanodon>
+						<BMT_Amargasaurus>0.3</BMT_Amargasaurus>
+						<BMT_Ankylosaurus>0.3</BMT_Ankylosaurus>
+						<BMT_Apatosaurus>0.2</BMT_Apatosaurus>
+						<BMT_Arthropleura>0.5</BMT_Arthropleura>
+						<BMT_Borealopelta>0.5</BMT_Borealopelta>
+						<BMT_Brachiosaurus>0.15</BMT_Brachiosaurus>
+						<BMT_Chungkingosaurus>0.5</BMT_Chungkingosaurus>
+						<BMT_Compsognathus>0.75</BMT_Compsognathus>
+						<BMT_Dimetrodon>0.5</BMT_Dimetrodon>
+						<BMT_Dryosaurus>0.1</BMT_Dryosaurus>
+						<BMT_Gallimimus>0.3</BMT_Gallimimus>
+						<BMT_Homalocephale>0.1</BMT_Homalocephale>
+						<BMT_Iguanodon>0.3</BMT_Iguanodon>
+						<BMT_Kaprosuchus>0.3</BMT_Kaprosuchus>
+						<BMT_Kentrosaurus>0.5</BMT_Kentrosaurus>
+						<BMT_Pachycephalosaurus>0.3</BMT_Pachycephalosaurus>
+						<BMT_Parasaur>0.4</BMT_Parasaur>
+						<BMT_Polacanthus>0.5</BMT_Polacanthus>
+						<BMT_Protoceratops>0.5</BMT_Protoceratops>
+						<BMT_Stegosaurus>0.5</BMT_Stegosaurus>
+						<BMT_Stygimoloch>0.4</BMT_Stygimoloch>
+						<BMT_Styracosaurus>0.5</BMT_Styracosaurus>
+						<BMT_TRex>0.1</BMT_TRex>
+						<BMT_Triceratops>0.3</BMT_Triceratops>
 					</value>
 				</li>
-				
-				<li Class="PatchOperationAdd"> 
+
+				<li Class="PatchOperationAdd">
 					<xpath>Defs/BiomeDef[defName="AB_PropaneLakes"]/wildAnimals</xpath>
 					<value>
-		    <BMT_Polacanthus>0.5</BMT_Polacanthus>
-		    <BMT_Borealopelta>0.5</BMT_Borealopelta>
-			<BMT_Homalocephale>0.05</BMT_Homalocephale>
+						<BMT_Borealopelta>0.5</BMT_Borealopelta>
+						<BMT_Homalocephale>0.05</BMT_Homalocephale>
+						<BMT_Polacanthus>0.5</BMT_Polacanthus>
 					</value>
 				</li>
-				
-				<li Class="PatchOperationAdd"> 
+
+				<li Class="PatchOperationAdd">
 					<xpath>Defs/BiomeDef[defName="AB_PyroclasticConflagration"]/wildAnimals</xpath>
 					<value>
-			<BMT_Dilophosaurus>0.05</BMT_Dilophosaurus>
+						<BMT_Dilophosaurus>0.05</BMT_Dilophosaurus>
 					</value>
 				</li>
-				
-				<li Class="PatchOperationAdd"> 
+
+				<li Class="PatchOperationAdd">
 					<xpath>Defs/BiomeDef[defName="AB_RockyCrags"]/wildAnimals</xpath>
 					<value>
-		    <BMT_Velociraptor>0.5</BMT_Velociraptor>
-			<BMT_Dilophosaurus>0.07</BMT_Dilophosaurus>
-			<BMT_Carnotaurus>0.03</BMT_Carnotaurus>
-			<BMT_Inostrancevia>0.01</BMT_Inostrancevia>
+						<BMT_Carnotaurus>0.03</BMT_Carnotaurus>
+						<BMT_Dilophosaurus>0.07</BMT_Dilophosaurus>
+						<BMT_Inostrancevia>0.01</BMT_Inostrancevia>
+						<BMT_Velociraptor>0.5</BMT_Velociraptor>
 					</value>
 				</li>
-				
-				<li Class="PatchOperationAdd"> 
+
+				<li Class="PatchOperationAdd">
 					<xpath>Defs/BiomeDef[defName="AB_TarPits"]/wildAnimals</xpath>
 					<value>
-		    <BMT_Velociraptor>0.5</BMT_Velociraptor>
-			<BMT_Dilophosaurus>0.07</BMT_Dilophosaurus>
-			<BMT_Carnotaurus>0.03</BMT_Carnotaurus>
-			<BMT_Inostrancevia>0.01</BMT_Inostrancevia>
+						<BMT_Carnotaurus>0.03</BMT_Carnotaurus>
+						<BMT_Dilophosaurus>0.07</BMT_Dilophosaurus>
+						<BMT_Inostrancevia>0.01</BMT_Inostrancevia>
+						<BMT_Velociraptor>0.5</BMT_Velociraptor>
 					</value>
 				</li>
-				
+
 			</operations>
 		</match>
 	</Operation>


### PR DESCRIPTION
Biomes! Prehistoric dilutes the spawn pool of certain biomes so much that the Alpha Animals required for that biome no longer spawn reliably.

This PR keeps the spawn chances of a specific biome animal at half of the original value or more in each Alpha Biome. It also adds support for missing alpha biomes and prehistoric animals.

A better view of the changes along with detailed notes can be found in the “Proposed” tab of this spreadsheet: https://docs.google.com/spreadsheets/d/1HCYIco2OUrVoFinpuzq69ZEKZEJlnS0RdNr0zi2EtRg/edit#g