### PR TITLE
Silence the Boomasaur 'Parsed 1.5 as int' warning

### DIFF
--- a/1.5/Defs/Animals/BMT_Boomasaur.xml
+++ b/1.5/Defs/Animals/BMT_Boomasaur.xml
@@ -63,7 +63,7 @@
 		<comps>
 			<li Class="CompProperties_Milkable">
 				<milkDef>Chemfuel</milkDef>
-				<milkIntervalDays>1.5</milkIntervalDays>
+				<milkIntervalDays>1</milkIntervalDays>
 				<milkAmount>15</milkAmount>
 				<milkFemaleOnly>false</milkFemaleOnly>
 			</li>


### PR DESCRIPTION
This changes the XML value to 1, which seems to be what was used.

RimWorld::CompProperties_Milkable seems to have public int milkIntervalDays, so it will take more than xml fiddling if it really needs to be 1.5 for some reason.

The 1.3 and 1.4 versions of the file still have the old value, as I haven't tested there.  Otherwise, this does remove the warning in the logs about "Parsed 1.5 as int".